### PR TITLE
Allow resource[:parameters][:content] == false

### DIFF
--- a/lib/puppet/catalog-diff/preprocessor.rb
+++ b/lib/puppet/catalog-diff/preprocessor.rb
@@ -76,7 +76,7 @@ module Puppet::CatalogDiff
           end
         end
 
-        if resource[:parameters].include?(:content)
+        if resource[:parameters].include?(:content) and resource[:parameters][:content] != false
           resource[:parameters][:content] = { :checksum => Digest::MD5.hexdigest(resource[:parameters][:content]), :content => resource[:parameters][:content] }
         end
 


### PR DESCRIPTION
In the unlikely event that a user has a puppet define with a parameter
named 'content' and this is false, puppet catalog diff will crash and
burn in a fiery blaze reminiscent of the Hindenburg disaster.

Less dramatically, this unhelpful error is what you get:

err: can't convert false into String
err: Try 'puppet help catalog diff' for usage
