### PR TITLE
More of "allow content to be non-string"

### DIFF
--- a/lib/puppet/catalog-diff/preprocessor.rb
+++ b/lib/puppet/catalog-diff/preprocessor.rb
@@ -103,7 +103,7 @@ module Puppet::CatalogDiff
           resource[:parameters][param] = value
         end
 
-        if resource[:parameters].include?(:content)
+        if resource[:parameters].include?(:content) and resource[:parameters][:content] != false
           resource[:parameters][:content] = { :checksum => Digest::MD5.hexdigest(resource[:parameters][:content]), :content => resource[:parameters][:content] }
         end
 


### PR DESCRIPTION
Same as before, but for the convert25 method.

In the unlikely event that a user has a puppet define with a parameter
named 'content' and this is false, puppet catalog diff will crash and
burn in a fiery blaze reminiscent of the Hindenburg disaster.

Less dramatically, this unhelpful error is what you get:

err: can't convert false into String
err: Try 'puppet help catalog diff' for usage
