### PR TITLE
Work with resource titles that are not Strings.

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -14,7 +14,7 @@ module Puppet::CatalogDiff
 
     # Prints a resource in a way that looks like puppet code
     def print_resource(resource)
-      puts "\t" + resource[:type].downcase + '{"' +  resource[:title] + '":'
+      puts "\t" + resource[:type].downcase + '{"' +  resource[:title].to_s + '":'
       resource[:parameters].each_pair do |k,v|
         if v.is_a?(Array)
           indent = " " * k.to_s.size


### PR DESCRIPTION
Fixes this:

puppet catalog diff 26catalogs/example.com.pson 27catalogs/example.com.pson
Resource counts:
        Old: 2168
        New: 2168

Resource title diffs:
Only in old:
Only in new:

Individual Resource differences:
Old Resource:
err: can't convert Fixnum into String
err: Try 'puppet help catalog diff' for usage
