### PR TITLE
Raise error if no file extension is provided for the catalogs

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -37,6 +37,8 @@ module Puppet::CatalogDiff
           tmp = Marshal.load(File.read(r))
         when '.pson'
           tmp = PSON.load(File.read(r))
+	else 
+	  raise "Provide catalog with the approprtiate file extension, valid extensions are pson, yaml and marshal"
         end
 
         if @version == "0.24"


### PR DESCRIPTION
Currently, if user doesn't provide an extension for catalogs, the output shows no changes. Can be a time waster, so we should raise an error. Or perhaps assume the default to be pson ? 
