### PR TITLE
Allow catalogs with .json extension

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -37,6 +37,8 @@ module Puppet::CatalogDiff
           tmp = Marshal.load(File.read(r))
         when '.pson'
           tmp = PSON.load(File.read(r))
+        when '.json'
+          tmp = PSON.load(File.read(r))
 	else 
 	  raise "Provide catalog with the approprtiate file extension, valid extensions are pson, yaml and marshal"
         end


### PR DESCRIPTION
In Puppet 3.2.x, the catalogs are written to the agents
data dir with the extension .json by default.

This commit ensures that you can perform diffs on these
catalogs.
