### PR TITLE
Sort dependency arrays before comparing params

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -52,6 +52,9 @@ module Puppet::CatalogDiff
         #resource[:parameters].delete(:command) unless new_resource[:parameters].include?(:command)
         #resource[:parameters].delete(:path) unless new_resource[:parameters].include?(:path)
 
+        sort_dependencies!(new_resource[:parameters])
+        sort_dependencies!(resource[:parameters])
+
         unless new_resource[:parameters] == resource[:parameters]
           puts "Old Resource:"
           print_resource(resource)
@@ -72,6 +75,17 @@ module Puppet::CatalogDiff
         end
 
       end
+    end
+
+    # sort require/before/notify/subscribe before comparison
+    def sort_dependencies!(params)
+      params.each do |x|
+        if [:require, :before, :notify, :subscribe].include?(x[0])
+          if x[1].class == Array
+            x[1].sort!
+          end
+        end
+      end  
     end
 
     # Takes arrays of resource titles and shows the differences


### PR DESCRIPTION
When using the -> syntax for assigning relationships,
the order in which the values are assigned to meta-parameters
can be non-deterministic.

This patch sorts arrays used to specify order in Puppet
to reduce differences that do not effect how configuration
is applied.
