### PR TITLE
Add option --show_resource_diff

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -9,6 +9,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary "Whether to show a diff for File resource content"
     end
 
+    option '--show_resource_diff' do
+      summary 'Allows differneces between resources to specified using unified diff format'
+    end
+
     description <<-'EOT'
       Prints the differences between catalogs compiled by different puppet master to help
       during migrating to a new Puppet version.


### PR DESCRIPTION
Currently, it is difficult to read the current resource
difference output format (esp when there are loads of
params for the resources).

This commit adds an option: --show_resource_diff which indicates
that resource differences should be displayed as a diff between
the resources and not as each entire resource.
