### PR TITLE
Add option --exclude_classes

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -50,6 +50,12 @@ module Puppet::CatalogDiff
         end
       end
 
+      if options[:exclude_classes]
+        [to, from].each do |x|
+          x.reject! {|x| x[:type] == 'Class' }
+        end
+      end 
+
       titles = {}
       titles[:to] = extract_titles(to)
       titles[:from] = extract_titles(from)

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -10,7 +10,11 @@ Puppet::Face.define(:catalog, '0.0.1') do
     end
 
     option '--show_resource_diff' do
-      summary 'Allows differneces between resources to specified using unified diff format'
+      summary 'Display differeces between resources in unified diff format'
+    end
+
+    option '--exclude_classes' do
+      summary 'Do not print classes in resource diffs'
     end
 
     description <<-'EOT'


### PR DESCRIPTION
Parameterized class declarations show
up as resources in the diff output.

It makes sense to ignore classes (esp when using
the catalog diff tool to validate a refactor) b/c
they don't effect the end state of a system (they
merely contain resources, which is what you really
should care about when doing a diff)

This commit adds an option which strips all classes
out of the list of resources being compared.
