### PR TITLE
support hashes in resource attributes

### DIFF
--- a/lib/puppet/catalog-diff/preprocessor.rb
+++ b/lib/puppet/catalog-diff/preprocessor.rb
@@ -104,6 +104,7 @@ module Puppet::CatalogDiff
         end
 
         if resource[:parameters].include?(:content) and resource[:parameters][:content] != false
+          resource[:parameters][:content] = Hash[resource[:parameters][:content].sort].to_pson if resource[:parameters][:content].class.to_s == 'Hash'
           resource[:parameters][:content] = { :checksum => Digest::MD5.hexdigest(resource[:parameters][:content]), :content => resource[:parameters][:content] }
         end
 


### PR DESCRIPTION
there is a chance that resource will be something along those lines...

```
    my::defined::check { "it's about time":
        command         => {
            "ntp"   => "check_ntp -H 127.0.0.1",
            "clock" => "/usr/local/bin/check_clock.sh -w 5 -c 10", 
        },
    }
```

let's make it supported!

now it just yells:

```
Error: can't convert Hash into String
```
