### PR TITLE
Ignore resources via option

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -64,7 +64,7 @@ module Puppet::CatalogDiff
         sort_dependencies!(new_resource[:parameters])
         sort_dependencies!(resource[:parameters])
 
-        next if options[:ignore_resources] and options[:ignore_resources].include? resource[:type] << '[' <<  resource[:title].to_s << ']'
+        next if options[:ignore_resources] && options[:ignore_resources].include? resource[:type] << '[' <<  resource[:title].to_s << ']'
 
         unless new_resource[:parameters] == resource[:parameters]
           diffs = true

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -87,7 +87,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
 
       # Faces don't currently have support for passing an option multiple times,
       # so we use a separator and split into an array here
-      if options[:ignore_resources] and options[:ignore_resources].include? '|'
+      if options[:ignore_resources] && options[:ignore_resources].include? '|'
         options[:ignore_resources] = options[:ignore_resources].split('|')
       end
 


### PR DESCRIPTION
adds an option to ignore one or more resources from the diffs. Since Faces don't seem to support specifying an option multiple times, multiple resources are passed in as a single string separated by pipe (|) and then split into an array.
